### PR TITLE
Add a setting to change which Hypar server you're using.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
 dist
+out
 *.vsix
 .DS_Store

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "hypar-function-builder",
 	"displayName": "Hypar Function Builder",
-	"version": "0.1.1",
+	"version": "0.1.2",
 	"description": "A live development and visualization environment for building Hypar functions.",
 	"engines": {
 		"vscode": "^1.32.0"
@@ -24,6 +24,17 @@
 				"category": "Hypar"
 			}
 		],
+		"configuration": {
+			"title": "Hypar Function Builder",
+			"properties": {
+				"hyparFunctionBuilder.hyparServer": {
+					"type": "string",
+					"default": "https://hypar.io",
+					"description": "The root URL of Hypar's servers.",
+					"format": "uri"
+				}
+			}
+		},
 		"taskDefinitions": [
 			{
 				"type": "Hypar"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -327,9 +327,13 @@ class HyparPanel {
 		// Use a nonce to whitelist which scripts can be run
 		const nonce = getNonce();
 		
-		const root = 'https://hypar.io';
-		// const root = 'https://dev.hypar.io';
-		// const root = 'http://localhost:8080';
+		let root = vscode.workspace.getConfiguration('hyparFunctionBuilder').hyparServer;
+		if (!root || root.length == 0) {
+			root = 'https://hypar.io'
+		}
+
+		// Remove outer whitespace and remove any trailing slashes.
+		root = root.trim().replace(/\/+$/, '')
 
 		return `<!DOCTYPE html>
 		<html lang="en">


### PR DESCRIPTION
This should make it much easier to test improve the way the site works with the extension, since you can now use http://localhost:8080 or https://dev.hypar.io.

You previously had to rebuild the extention to do this, so nobody did it.